### PR TITLE
Dev

### DIFF
--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "GameManagerCloud Daemon"
-#define MyAppVersion "1.1.0-EA"
+#define MyAppVersion "1.2.0-EA"
 #define MyAppPublisher "SwiftByte Kaspereit Faust Steurer GbR"
 #define MyAppURL "https://gamemanager.cloud"
 #define MyAppExeName "GmcDaemon.exe"

--- a/installer.iss
+++ b/installer.iss
@@ -1,5 +1,5 @@
 #define MyAppName "GameManagerCloud Daemon"
-#define MyAppVersion "1.0.0-EA"
+#define MyAppVersion "1.1.0-EA"
 #define MyAppPublisher "SwiftByte Kaspereit Faust Steurer GbR"
 #define MyAppURL "https://gamemanager.cloud"
 #define MyAppExeName "GmcDaemon.exe"

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.swiftbyte.gmc</groupId>
             <artifactId>GmcCommon</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>xyz.astroark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.swiftbyte.gmc</groupId>
     <artifactId>GmcDaemon</artifactId>
-    <version>1.1.0-EA</version>
+    <version>1.2.0-EA</version>
     <name>GmcDaemon</name>
     <description>GameManagerCloud Daemon</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.swiftbyte.gmc</groupId>
             <artifactId>GmcCommon</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.10</version>
         </dependency>
         <dependency>
             <groupId>xyz.astroark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>de.swiftbyte.gmc</groupId>
     <artifactId>GmcDaemon</artifactId>
-    <version>1.0.1-EA</version>
+    <version>1.1.0-EA</version>
     <name>GmcDaemon</name>
     <description>GameManagerCloud Daemon</description>
     <packaging>jar</packaging>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.swiftbyte.gmc</groupId>
             <artifactId>GmcCommon</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>xyz.astroark</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>de.swiftbyte.gmc</groupId>
             <artifactId>GmcCommon</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.8</version>
         </dependency>
         <dependency>
             <groupId>xyz.astroark</groupId>

--- a/src/main/java/de/swiftbyte/gmc/server/AsaServer.java
+++ b/src/main/java/de/swiftbyte/gmc/server/AsaServer.java
@@ -289,6 +289,10 @@ public class AsaServer extends GameServer {
                 restartCounter = 0;
             }
         }
+
+        if(state != GameServerState.ONLINE) {
+            currentOnlinePlayers = 0;
+        }
     }
 
     @Override

--- a/src/main/java/de/swiftbyte/gmc/server/AsaServer.java
+++ b/src/main/java/de/swiftbyte/gmc/server/AsaServer.java
@@ -81,11 +81,7 @@ public class AsaServer extends GameServer {
                 if (process.exitValue() == 7 || process.exitValue() == 0) {
                     log.debug("Server was installed successfully!");
 
-                    if (Node.INSTANCE.isManageFirewallAutomatically()) {
-                        log.debug("Adding firewall rules for server '" + friendlyName + "'...");
-
-                        allowFirewallPorts();
-                    }
+                    allowFirewallPorts();
 
                     super.setState(GameServerState.OFFLINE);
                 } else {
@@ -285,9 +281,7 @@ public class AsaServer extends GameServer {
                 if (CommonUtils.getProcessPID(String.valueOf(installDir)) == null)
                     super.setState(GameServerState.OFFLINE);
             }
-            case OFFLINE -> {
-                restartCounter = 0;
-            }
+            case OFFLINE -> restartCounter = 0;
         }
 
         if(state != GameServerState.ONLINE) {

--- a/src/main/java/de/swiftbyte/gmc/server/GameServer.java
+++ b/src/main/java/de/swiftbyte/gmc/server/GameServer.java
@@ -83,8 +83,11 @@ public abstract class GameServer {
     public abstract String sendRconCommand(String command);
 
     public void allowFirewallPorts() {
-        Path executablePath = Path.of(installDir + "/ShooterGame/Binaries/Win64/ArkAscendedServer.exe");
-        FirewallService.allowPort(friendlyName, executablePath, new int[]{settings.getGamePort(), settings.getGamePort() + 1, settings.getQueryPort(), settings.getRconPort()});
+        if (Node.INSTANCE.isManageFirewallAutomatically()) {
+            log.debug("Adding firewall rules for server '" + friendlyName + "'...");
+            Path executablePath = Path.of(installDir + "/ShooterGame/Binaries/Win64/ArkAscendedServer.exe");
+            FirewallService.allowPort(friendlyName, executablePath, new int[]{settings.getGamePort(), settings.getGamePort() + 1, settings.getQueryPort(), settings.getRconPort()});
+        }
     }
 
     public void setState(GameServerState state) {
@@ -106,7 +109,7 @@ public abstract class GameServer {
     }
 
     public void setSettings(ServerSettings settings) {
-        FirewallService.removePort(friendlyName);
+        if(Node.INSTANCE.isManageFirewallAutomatically()) FirewallService.removePort(friendlyName);
         this.settings = settings;
         allowFirewallPorts();
     }

--- a/src/main/java/de/swiftbyte/gmc/stomp/StompHandler.java
+++ b/src/main/java/de/swiftbyte/gmc/stomp/StompHandler.java
@@ -113,7 +113,7 @@ public class StompHandler {
 
                         @Override
                         public void handleFrame(StompHeaders headers, Object payload) {
-                            packetConsumer.onReceive(payload);
+                            new Thread(() -> packetConsumer.onReceive(payload)).start();
                         }
                     });
                 }

--- a/src/main/java/de/swiftbyte/gmc/stomp/StompHandler.java
+++ b/src/main/java/de/swiftbyte/gmc/stomp/StompHandler.java
@@ -31,8 +31,8 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class StompHandler {
 
-    // 1MB
-    private static final int MAX_MESSAGE_BUFFER_SIZE_BYTES = 1024 * 1024;
+    // 2MB
+    private static final int MAX_MESSAGE_BUFFER_SIZE_BYTES = 1024 * 1024 * 2;
 
     private static StompSession session;
 
@@ -41,6 +41,7 @@ public class StompHandler {
         WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         container.setDefaultMaxTextMessageBufferSize(MAX_MESSAGE_BUFFER_SIZE_BYTES);
         WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient(container));
+        stompClient.setInboundMessageSizeLimit(MAX_MESSAGE_BUFFER_SIZE_BYTES);
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
         headers.add("Node-Id", Node.INSTANCE.getNodeId());
         headers.add("Node-Secret", Node.INSTANCE.getSecret());

--- a/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
+++ b/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
@@ -142,6 +142,8 @@ public class ServerUtils {
         if (!settings.isEnableBattlEye()) requiredLaunchParameters1.add("NoBattlEye");
         if (!CommonUtils.isNullOrEmpty(settings.getCulture()))
             requiredLaunchParameters1.add("culture=" + settings.getCulture());
+        if (!CommonUtils.isNullOrEmpty(settings.getClusterId()))
+            requiredLaunchParameters1.add("clusterID=" + settings.getClusterId());
         return requiredLaunchParameters1;
     }
 

--- a/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
+++ b/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
@@ -41,7 +41,7 @@ public class ServerUtils {
                 .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> (arg.contains(requiredArg.split("=")[0]))))
                 .forEach(arg -> {
                     if (CommonUtils.isNullOrEmpty(arg)) return;
-                    if (!arg.contains("-")) preArgs.append(" -");
+                    if (!arg.replace(" ", "").startsWith("-")) preArgs.append(" -");
                     else preArgs.append(" ");
                     preArgs.append(arg);
                 });

--- a/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
+++ b/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
@@ -144,6 +144,9 @@ public class ServerUtils {
             requiredLaunchParameters1.add("culture=" + settings.getCulture());
         if (!CommonUtils.isNullOrEmpty(settings.getClusterId()))
             requiredLaunchParameters1.add("clusterID=" + settings.getClusterId());
+        if (!CommonUtils.isNullOrEmpty(settings.getClusterDirOverride()))
+            requiredLaunchParameters1.add("ClusterDirOverride=\"" + settings.getClusterDirOverride()+"\"");
+        if (settings.isNoTransferFromFiltering()) requiredLaunchParameters1.add("notransferfromfiltering");
         return requiredLaunchParameters1;
     }
 

--- a/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
+++ b/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
@@ -38,7 +38,10 @@ public class ServerUtils {
         requiredArgs2.forEach(arg -> preArgs.append(" -").append(arg));
 
         argsType2.stream()
-                .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> (arg.contains(requiredArg.split("=")[0]))))
+                .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> {
+                    log.info("Checking if " + arg + " contains " + requiredArg.split("=")[0]);
+                    return (arg.contains(requiredArg.split("=")[0]));
+                }))
                 .forEach(arg -> {
                     if (CommonUtils.isNullOrEmpty(arg)) return;
                     if (!arg.replace(" ", "").startsWith("-")) preArgs.append(" -");
@@ -142,10 +145,11 @@ public class ServerUtils {
         if (!settings.isEnableBattlEye()) requiredLaunchParameters1.add("NoBattlEye");
         if (!CommonUtils.isNullOrEmpty(settings.getCulture()))
             requiredLaunchParameters1.add("culture=" + settings.getCulture());
-        if (!CommonUtils.isNullOrEmpty(settings.getClusterId()))
+        if (!CommonUtils.isNullOrEmpty(settings.getClusterId())) {
             requiredLaunchParameters1.add("clusterID=" + settings.getClusterId());
-        if (!CommonUtils.isNullOrEmpty(settings.getClusterDirOverride()))
-            requiredLaunchParameters1.add("ClusterDirOverride=\"" + settings.getClusterDirOverride()+"\"");
+            if (!CommonUtils.isNullOrEmpty(settings.getClusterDirOverride()))
+                requiredLaunchParameters1.add("ClusterDirOverride=\"" + settings.getClusterDirOverride()+"\"");
+        }
         if (settings.isNoTransferFromFiltering()) requiredLaunchParameters1.add("notransferfromfiltering");
         return requiredLaunchParameters1;
     }

--- a/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
+++ b/src/main/java/de/swiftbyte/gmc/utils/ServerUtils.java
@@ -26,7 +26,7 @@ public class ServerUtils {
         preArgs.delete(preArgs.length() - 1, preArgs.length());
 
         argsType1.stream()
-                .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> (arg.contains(requiredArg.split("=")[0]))))
+                .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> (arg.split("=")[0].equalsIgnoreCase(requiredArg.split("=")[0]))))
                 .forEach(arg -> {
                     if (CommonUtils.isNullOrEmpty(arg)) return;
                     if (!arg.contains("?")) preArgs.append("?");
@@ -38,10 +38,7 @@ public class ServerUtils {
         requiredArgs2.forEach(arg -> preArgs.append(" -").append(arg));
 
         argsType2.stream()
-                .filter(arg -> requiredArgs1.stream().noneMatch(requiredArg -> {
-                    log.info("Checking if " + arg + " contains " + requiredArg.split("=")[0]);
-                    return (arg.contains(requiredArg.split("=")[0]));
-                }))
+                .filter(arg -> requiredArgs2.stream().noneMatch(requiredArg -> (arg.split("=")[0].equalsIgnoreCase(requiredArg.split("=")[0]))))
                 .forEach(arg -> {
                     if (CommonUtils.isNullOrEmpty(arg)) return;
                     if (!arg.replace(" ", "").startsWith("-")) preArgs.append(" -");


### PR DESCRIPTION
# GMC Update `1.2-EA`

## CHANGE LOG

```
+ force deletion of server is now possible when node offline
+ added new cluster settings (ClusterDirOverride, notransferfromfiltering) to GMC
+ Added custom scrollbars
• fixed a bug that caused the name of the used Ark Map was not allowed to appear in a start argument
• fixed a bug that caused the user to have to log in twice
• fixed a bug that caused the daemon to await a command to be executed before executing another one
• fixed a bug that caused the daemon to manage the firewall even though it was disabled
• fixed a bug that caused the frontend to endlessly load all servers from the backend
• fixed an error that occurred when deleting a node
• reduced size of packets that were send between components of GMC
• increased daemon max messaging size to 2 MB
• added translation for restarting status
• added translation for successful node registration
• changed mouse cursor to pointer when hovering over clickable server name
• Changed server icon
• Servers won't start on system boot by default anymore
• Daemon auto update enabled by default
• Daemon automatic firewall management enabled by default
• Daemon auto update enabled by default
• Fixed session expiry after one day
• Server state 'unknown' is now shown as 'node offline'
• Adjusted add server popup width
• Fixed incorrect player count for servers
• Login page layout adjustments
• Server state 'creating' is shown as 'creating/updating'
• GMC adds nodes and servers without reloading.
• fixed some more design bugs
```

## IN PROGRESS
```
+ All ARK Settings
+ ARK Auto Update
+ ASE Support
```